### PR TITLE
Add gen1 agent support for scarthgap

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $HOME
         └── sstate-cache                          # post successful yocto build
 ```
 
-### Quick Steps
+### Quick Steps - Gen 1
 
 ```sh
 # Clone the main yocto repo that has install-deps.sh, setup.sh, and build.sh scripts.
@@ -76,6 +76,20 @@ popd
 # List the deployment .wic file and symlink to it.
 pushd ~/adu_yocto/out
 find . -type f -name '*.wic' | grep -i deploy
+```
+
+
+### Quick Steps - Gen 2
+
+```sh
+# Same as Quick Steps - Gen 1, but provide cmdline arg overrides for build.sh
+# For example:
+
+./scripts/build.sh -c -t Debug -o ~/adu_yocto/out \
+    --adu-git-branch 'main' \
+    --adu-git-commit 'e981f7a9af5f561f98a3be9ea9563f4d0f256e63' \
+    --adu-src-uri 'git://github.com/Azure/device-update'
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ find . -type f -name '*.wic' | grep -i deploy
 ### Quick Steps - Gen 2
 
 ```sh
-# Same as Quick Steps - Gen 1, but provide cmdline arg overrides for build.sh
+# Same as Quick Steps - Gen 1, but provide cmdline arg overrides for build.sh and --adu-generation "2"
 # For example:
 
 ./scripts/build.sh -c -t Debug -o ~/adu_yocto/out \
+    --adu-generation "2" \
     --adu-git-branch 'main' \
     --adu-git-commit 'e981f7a9af5f561f98a3be9ea9563f4d0f256e63' \
     --adu-src-uri 'git://github.com/Azure/device-update'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $HOME
     │   └── yocto
     │       ├── config-templates
     │       ├── meta-azure-device-update          # DU Agent yocto recipes
-    │       ├── meta-iot-hub-device-update-delta  # Delta updates recipe - (Currently DISABLED)
+    │       ├── meta-iot-hub-device-update-delta  # Delta updates recipe - (Currently NOT working)
     │       ├── meta-openembedded                 # OpenEmbedded layers
     │       ├── meta-raspberrypi                  # RPi layers
     │       ├── meta-raspberrypi-adu              # ADU-specific RPi layer

--- a/README.md
+++ b/README.md
@@ -88,22 +88,22 @@ Before getting started with this project, please get yourself familiar with the 
 
 ### Get Source Code
 
-Please note that, at the time of this writing, we only support `kirkstone` release of the Yocto Project. 
+Please note that, at the time of this writing, we only support `scarthgap` release of the Yocto Project. 
 
 The following variables are referenced in the below section setting up the build. 
 
 | Variable Name | Description |
 |---|---|
-| $yocto_release | A name of the version of the Yocto Project used to build the images.<br/>(Only support `kirkstone` at the moment) |
+| $yocto_release | A name of the version of the Yocto Project used to build the images.<br/>(Only support `scarthgap` at the moment) |
 | $project_root  | A root directory where this project will be cloned into.|
 | $adu_release   | The release of Device Update you're planning on using (should default to `'main'`) | 
 
-You can either just include the string wholesale in the terminal (eg for `$yocto_release` just use `'kirkstone'`) or set the variable at the beginning and then copy the command from this screen.
+You can either just include the string wholesale in the terminal (eg for `$yocto_release` just use `'scarthgap'`) or set the variable at the beginning and then copy the command from this screen.
 
 You can set a bash variable like `yocto_release` like this:
 
 ```sh
-yocto_release=kirkstone
+yocto_release=scarthgap
 ```
 and for `adu_release` like this: 
 
@@ -227,7 +227,7 @@ If successful, the output image file (adu-base-image-raspberrypi4-64.wic.gz) and
 
 | Board | Branch | Status |
 |---|---|---|
-| Raspberry Pi 4 | kirkstone | [![Build Status](https://dev.azure.com/azure-device-update/adu-linux-client/_apis/build/status/azure.iot-hub-device-update-yocto?branchName=honister)](https://dev.azure.com/azure-device-update/adu-linux-client/_build/latest?definitionId=57&branchName=kirkstone)|
+| Raspberry Pi 4 | scarthgap | [![Build Status](https://dev.azure.com/azure-device-update/adu-linux-client/_apis/build/status/azure.iot-hub-device-update-yocto?branchName=scarthgap)](https://dev.azure.com/azure-device-update/adu-linux-client/_build/latest?definitionId=57&branchName=scarthgap)|
 
 
 ## Using Your Own Board and Guidance for Production Images

--- a/azurepipelines/build-template.yml
+++ b/azurepipelines/build-template.yml
@@ -5,7 +5,6 @@ parameters:
   default: scarthgap
   values:
     - scarthgap
-    - kirkstone
 - name: adu_src_uri
   displayName: "ADU Source URI"
   type: string

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -35,6 +35,7 @@ Usage: build.sh [options...]
                                      e.g. --clean-fetch-recipe azure-device-update
 
     -o, --out-dir <build_dir>        Set the build output directory. Default is build.
+    --verbose                        Add -v to bitbake cmdline for verbose output.
 
     -h, --help                       Show this help message.
 ENDOFUSAGE
@@ -74,6 +75,7 @@ BUILD_AZIOT_C_SDK_ONLY=0
 BUILD_ADU_DELTA_ONLY=0
 CLEAN_FETCH_RECIPE=''
 ADU_GEN=1
+VERBOSE=''
 SET_ENV_ONLY=0
 
 while [[ $1 != "" ]]; do
@@ -162,6 +164,9 @@ while [[ $1 != "" ]]; do
         shift
         BUILD_DIR=$1
         ;;
+    --verbose)
+        VERBOSE='-v'
+        ;;
     *)
         print_help
         exit 1
@@ -233,19 +238,19 @@ export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS ADU_GIT_BRANC
 source $ROOT_DIR/poky/oe-init-build-env $BUILD_DIR
 
 if [[ $CLEAN_FETCH_RECIPE != '' ]]; then
-    bitbake -c cleanall "$CLEAN_FETCH_RECIPE"
-    bitbake -c fetch "$CLEAN_FETCH_RECIPE" -v
+    bitbake $VERBOSE -c cleanall "$CLEAN_FETCH_RECIPE"
+    bitbake $VERBOSE -c fetch "$CLEAN_FETCH_RECIPE"
 elif [[ $BUILD_CORE_IMAGE_ONLY == 1 ]]; then
-    bitbake \
+    bitbake $VERBOSE \
         core-image-full-cmdline \
         core-image-minimal
 elif [[ $BUILD_AZIOT_C_SDK_ONLY == 1 ]]; then
-    bitbake azure-iot-sdk-c
+    bitbake $VERBOSE azure-iot-sdk-c
 elif [[ $BUILD_ADU_DELTA_ONLY == 1 ]]; then
-    bitbake -c clean -C compile -f azure-device-update-diffs
+    bitbake $VERBOSE -c clean -C compile -f azure-device-update-diffs
 else
     if [[ $CLEAN == 'true' ]]; then
-        bitbake -c cleanall  -f \
+        bitbake $VERBOSE -c cleanall  -f \
             azure-device-update \
             adu-agent-service \
             azure-iot-sdk-c \
@@ -255,10 +260,10 @@ else
             core-image-full-cmdline \
             core-image-minimal 
 
-        bitbake -c cleanall  -f \
+        bitbake $VERBOSE -c cleanall  -f \
             adu-base-image \
             adu-update-image
     fi
 
-    bitbake -DDD adu-update-image
+    bitbake $VERBOSE adu-update-image
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -26,6 +26,7 @@ print_help()
     echo "--core-image-only             Build the core-image only."
     echo "--aziot-c-sdk-only            Build Azure IoT C SDK only."
     echo "--adu-delta-only              Build Azure Device Update Delta library only."
+    echo "--adu-generation              The generation of the azure device update agent. Options are 1 and 2. Default is 1."
     echo "-o, --out-dir <build_dir>     Set the build output directory. Default is build."
     echo ""
     echo "-p, --private-preview         Build private preview version (use docs before renamed to deliveryoptimization-agent."
@@ -53,6 +54,7 @@ REBUILD=false
 BUILD_CORE_IMAGE_ONLY=0
 BUILD_AZIOT_C_SDK_ONLY=0
 BUILD_ADU_DELTA_ONLY=0
+ADU_GEN=1
 SET_ENV_ONLY=0
 
 while [[ $1 != "" ]]; do
@@ -107,6 +109,14 @@ while [[ $1 != "" ]]; do
         echo "build ADU Delta lib only..."
         BUILD_ADU_DELTA_ONLY=1
         ;;
+    --adu-generation)
+        shift
+        ADU_GEN="$1"
+        if [[ $ADU_GEN != 1 && $ADU_GEN != 2 ]]; then
+            echo "Invalid --adu-generation value: $ADU_GEN" >&2
+            exit 1
+        fi
+        ;;
     --set-env-only)
         SET_ENV_ONLY=1
         ;;
@@ -141,6 +151,7 @@ while [[ $1 != "" ]]; do
 done
 
 export MACHINE=raspberrypi4-64
+export ADU_GENERATION="$ADU_GEN"
 
 # Need to work on what this is
 export TEMPLATECONF=$ROOT_DIR/meta-raspberrypi-adu/conf/templates/$MACHINE/

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,7 +40,7 @@ ENDOFUSAGE
 
 # Defaults - Gen 1
 ADU_GIT_BRANCH='develop'
-ADU_SRC_URI='git://github.com/Azure/iot-hub-device-update'
+ADU_SRC_URI='https://github.com/Azure/iot-hub-device-update'
 SRC_URI="${ADU_SRC_URI};protocol=https;branch=${ADU_GIT_BRANCH}"
 ADU_GIT_COMMIT='350a551dd9d3f5639eddceb75ef5b10e834865fe'
 BUILD_TYPE='Debug'


### PR DESCRIPTION
- Remove or replace with scarthgap references to kirkstone and honister
- Add --adu-generation option to specify gen "1" or gen "2"
- Add --clean-fetch-recipe <recipe name> option to troubleshoot when do_fetch is not working
- Remove unused -p | --private-preview option
- Add --verbose option for verbose bitbake
- Update README.md Quick Steps for Gen 1 vs Gen 2