### PR TITLE
feat: enhance build.sh with auto-commit fetching, parallel builds, and persistent cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,24 +73,24 @@ popd
 # Launch bitbake to build the .wic image as per the yocto recipes.
 #
 # Build with default branches (automatically fetches latest commit from branch):
-# ./scripts/build.sh -c -t Debug -o ~/adu_yocto/out
+# ./scripts/build.sh -c -t Debug -o ~/yocto_build_dir
 #
 # Build with specific branch (automatically fetches HEAD commit):
-# ./scripts/build.sh -c -t Debug -o ~/adu_yocto/out --adu-git-branch feature/v-next
+# ./scripts/build.sh -c -t Debug -o ~/yocto_build_dir --adu-git-branch feature/v-next
 #
 # Optional: Specify ADU Branch and Commit explicitly
-# ./scripts/build.sh -c -t Debug -o ~/adu_yocto/out --adu-git-branch release/1.2.0 --adu-git-commit 9cf04c49d49b587712d01e9db6e1870a70959682
+# ./scripts/build.sh -c -t Debug -o ~/yocto_build_dir --adu-git-branch release/1.2.0 --adu-git-commit 9cf04c49d49b587712d01e9db6e1870a70959682
 #
 # Use parallel builds for faster compilation (uses all CPU cores by default):
-# ./scripts/build.sh -c -t Debug -o ~/adu_yocto/out -j 8 --parallel-make 8
+# ./scripts/build.sh -c -t Debug -o ~/yocto_build_dir -j 8 --parallel-make 8
 #
 # Full rebuild (preserves sstate cache for faster rebuilds):
-# ./scripts/build.sh --rebuild -t Debug -o ~/adu_yocto/out --adu-git-branch feature/v-next
+# ./scripts/build.sh --rebuild -t Debug -o ~/yocto_build_dir --adu-git-branch feature/v-next
 
-./scripts/build.sh -c -t Debug -o ~/adu_yocto/out
+./scripts/build.sh -c -t Debug -o ~/yocto_build_dir
 
 # List the deployment .wic file and symlink to it.
-pushd ~/adu_yocto/out
+pushd ~/yocto_build_dir
 find . -type f -name '*.wic' | grep -i deploy
 ```
 
@@ -271,12 +271,118 @@ You can use:
 ```
 to see the list of all options for the build.
 
-If successful, the output image file (adu-base-image-raspberrypi4-64.wic.gz) and example .swu update file (adu-update-image.swu) should be located in `$build_output_dir/tmp/deploy/images/raspberrypi4-64` directory. If you built for version 0.0.0.1 you will need to copy the base file out and run the build again to produce a Sw Update update (file ending `.swu`) to be used for the update. You need to do this to make a usable base and update image. 
+If successful, the output image file (adu-base-image-raspberrypi4-64.wic.gz) and example .swu update file (adu-update-image.swu) should be located in `~/yocto_build_dir/tmp/deploy/images/raspberrypi4-64` directory. If you built for version 0.0.0.1 you will need to copy the base file out and run the build again to produce a Sw Update update (file ending `.swu`) to be used for the update. You need to do this to make a usable base and update image. 
 
 ```sh
 .
 ├── adu-base-image-raspberrypi4-64.wic.gz
 ├── adu-update-image-raspberrypi4-64.swu
+```
+
+## Software Bill of Materials (SBOM)
+
+### Overview
+
+Yocto automatically generates comprehensive Software Bill of Materials (SBOM) in SPDX 2.2 format for all builds. The SBOM provides complete dependency tracking, license information, and package metadata for compliance and security auditing.
+
+### SBOM Location
+
+After a successful build, SBOM files are located at:
+
+```sh
+# Main SBOM archive (compressed, contains all packages)
+~/yocto_build_dir/tmp/deploy/images/raspberrypi4-64/adu-base-image-raspberrypi4-64.spdx.tar.zst
+
+# Individual SPDX JSON files for each package
+~/yocto_build_dir/tmp/deploy/spdx/
+```
+
+### Extracting and Viewing SBOM
+
+To extract and view the SBOM:
+
+```sh
+cd ~/yocto_build_dir/tmp/deploy/images/raspberrypi4-64
+
+# Extract the SBOM archive
+tar -xf adu-base-image-raspberrypi4-64.spdx.tar.zst
+
+# List all SPDX files
+ls -lh *.spdx.json | wc -l  # Shows total number of packages
+
+# View Azure Device Update dependencies
+python3 -m json.tool recipe-azure-device-update.spdx.json | less
+```
+
+### SBOM Contents
+
+Each SPDX file contains:
+
+- **Package Information**: Name, version, description, homepage
+- **License Information**: SPDX license identifiers and copyright text
+- **Dependencies**: Complete build and runtime dependency trees
+- **Source Information**: Download URLs, Git repositories, commit hashes
+- **File Checksums**: SHA1, SHA256 checksums for verification
+- **Relationships**: Package relationships (DEPENDS, RDEPENDS, CONTAINS)
+
+### Tracking meta-azure-device-update Dependencies
+
+The `azure-device-update` package has the following direct build dependencies:
+
+- azure-iot-sdk-c
+- azure-sdk-for-cpp
+- curl
+- deliveryoptimization-agent
+- deliveryoptimization-sdk
+- catch2 (test framework)
+- glibc, gcc-runtime (core libraries)
+
+To view all dependencies:
+
+```sh
+cd ~/yocto_build_dir/tmp/deploy/images/raspberrypi4-64
+
+# View recipe dependencies
+python3 -c "
+import json
+with open('recipe-azure-device-update.spdx.json') as f:
+    data = json.load(f)
+    print('Build Dependencies:')
+    for ref in data['externalDocumentRefs']:
+        print('  -', ref['externalDocumentId'].replace('DocumentRef-dependency-recipe-', ''))
+"
+
+# View runtime dependencies
+cat runtime-azure-device-update.spdx.json | python3 -m json.tool
+```
+
+### SBOM Format Details
+
+The build generates SPDX 2.2 JSON format, which includes:
+
+- **SPDX-2.2 Specification**: Industry-standard format recognized by security scanning tools
+- **Namespace URIs**: Unique identifiers for each document
+- **External References**: Links between packages showing dependency relationships
+- **Creation Info**: Build timestamp, tool information, and creator details
+
+### Using SBOM for Compliance
+
+The generated SBOM can be used for:
+
+1. **License Compliance**: Identify all open source licenses in your image
+2. **Security Scanning**: Feed into vulnerability scanners (e.g., Grype, Trivy)
+3. **Supply Chain Security**: Track component provenance
+4. **Export Control**: Identify restricted components
+5. **Regulatory Compliance**: Meet software transparency requirements
+
+Example using with security scanners:
+
+```sh
+# Using Grype (example)
+grype sbom:./adu-base-image-raspberrypi4-64.spdx.tar.zst
+
+# Using Syft to convert formats (example)
+syft convert ./adu-base-image-raspberrypi4-64.spdx.tar.zst -o cyclonedx-json
 ```
 
 ## Build Pipelines Status

--- a/README.md
+++ b/README.md
@@ -72,11 +72,20 @@ popd
 
 # Launch bitbake to build the .wic image as per the yocto recipes.
 #
-# Build with default branches and commits:
+# Build with default branches (automatically fetches latest commit from branch):
 # ./scripts/build.sh -c -t Debug -o ~/adu_yocto/out
 #
-# Optional: Specify ADU Branch and Commit
+# Build with specific branch (automatically fetches HEAD commit):
+# ./scripts/build.sh -c -t Debug -o ~/adu_yocto/out --adu-git-branch feature/v-next
+#
+# Optional: Specify ADU Branch and Commit explicitly
 # ./scripts/build.sh -c -t Debug -o ~/adu_yocto/out --adu-git-branch release/1.2.0 --adu-git-commit 9cf04c49d49b587712d01e9db6e1870a70959682
+#
+# Use parallel builds for faster compilation (uses all CPU cores by default):
+# ./scripts/build.sh -c -t Debug -o ~/adu_yocto/out -j 8 --parallel-make 8
+#
+# Full rebuild (preserves sstate cache for faster rebuilds):
+# ./scripts/build.sh --rebuild -t Debug -o ~/adu_yocto/out --adu-git-branch feature/v-next
 
 ./scripts/build.sh -c -t Debug -o ~/adu_yocto/out
 
@@ -106,21 +115,6 @@ rpi4> chown adu:adu status_monitor
 rpi4> su -p adu
 rpi4> ./status_monitor
 ```
-
-### Quick Steps - Gen 2
-
-```sh
-# Same as Quick Steps - Gen 1, but provide cmdline arg overrides for build.sh and --adu-generation "2"
-# For example:
-
-./scripts/build.sh -c -t Debug -o ~/adu_yocto/out \
-    --adu-generation "2" \
-    --adu-git-branch 'main' \
-    --adu-git-commit 'e981f7a9af5f561f98a3be9ea9563f4d0f256e63' \
-    --adu-src-uri 'git://github.com/Azure/device-update'
-
-```
-
 
 ## Prerequisites
 
@@ -245,10 +239,29 @@ You can find the instructions for generating the private key and creating the pa
 
 ### Build The Project
 
-To build the project you can either use our helper script or read the `build.sh` script and use your own terminal  commands to build the layer. Keep in mind Yocto builds can take time depending on your machine. It's best to use a local cache if you're going to be running multiple builds. We use the `-o` option to specify the output directory which in turn builds a local cache that can expedite your local builds. An example invocation is specified below. It is executed from the repositories root folder. NOT the `yocto` directory.
+To build the project you can either use our helper script or read the `build.sh` script and use your own terminal commands to build the layer. Keep in mind Yocto builds can take time depending on your machine. It's best to use a local cache if you're going to be running multiple builds. We use the `-o` option to specify the output directory which in turn builds a local cache that can expedite your local builds. An example invocation is specified below. It is executed from the repositories root folder. NOT the `yocto` directory.
 
 ```sh
 ./scripts/build.sh -c -t Debug -o ~/yocto_build_dir
+```
+
+#### New Features in build.sh
+
+**Automatic Commit Hash Fetching**: When you specify `--adu-git-branch` without `--adu-git-commit`, the script automatically fetches and uses the HEAD commit hash of that branch. This ensures reproducible builds while staying current with your development branch.
+
+**Parallel Builds**: Use `-j` and `--parallel-make` options to speed up compilation by using multiple CPU cores. By default, the script detects and uses all available CPU cores.
+
+**Persistent SState Cache**: The `--rebuild` flag now preserves the sstate-cache directory, making subsequent full rebuilds much faster by reusing unchanged compilation artifacts.
+
+```sh
+# Use all CPU cores for parallel builds (auto-detected)
+./scripts/build.sh -c -t Debug -o ~/yocto_build_dir
+
+# Explicitly set parallel jobs
+./scripts/build.sh -c -t Debug -o ~/yocto_build_dir -j 8 --parallel-make 8
+
+# Full rebuild with cache preservation
+./scripts/build.sh --rebuild -t Debug -o ~/yocto_build_dir --adu-git-branch feature/v-next
 ```
 
 You can use:
@@ -256,9 +269,9 @@ You can use:
 ```sh
 ./scripts/build.sh -h
 ```
-to see the list of all options for the build. 
+to see the list of all options for the build.
 
-If successful, the output image file (adu-base-image-raspberrypi4-64.wic.gz) and example .swu update file (adu-update-image-raspberrypi4-64.swu) should be located in `$build_output_dir/tmp/deploy/images/raspberrypi4-64` directory. If you built for version 0.0.0.1 you will need to copy the base file out and run the build again to produce a Sw Update update (file ending `.swu`) to be used for the update. You need to do this to make a usable base and update image. 
+If successful, the output image file (adu-base-image-raspberrypi4-64.wic.gz) and example .swu update file (adu-update-image.swu) should be located in `$build_output_dir/tmp/deploy/images/raspberrypi4-64` directory. If you built for version 0.0.0.1 you will need to copy the base file out and run the build again to produce a Sw Update update (file ending `.swu`) to be used for the update. You need to do this to make a usable base and update image. 
 
 ```sh
 .

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,6 +47,9 @@ Usage: build.sh [options...]
 
     -o, --out-dir <build_dir>        Set the build output directory. Default is build.
     --verbose                        Add -v to bitbake cmdline for verbose output.
+    
+    -j, --jobs <number>              Number of parallel tasks BitBake should run. Default is number of CPU cores.
+    --parallel-make <number>         Number of processes 'make' should run in parallel. Default is number of CPU cores.
 
     -h, --help                       Show this help message.
 ENDOFUSAGE
@@ -55,7 +58,7 @@ ENDOFUSAGE
 # Defaults - Gen 1
 ADU_GIT_BRANCH='develop'
 ADU_SRC_URI='git://github.com/Azure/iot-hub-device-update'
-ADU_GIT_COMMIT='d226c1ef8da00daf070f001ebc7cda92725ea759'
+ADU_GIT_COMMIT=''
 BUILD_TYPE='Debug'
 WITH_FEATURE_DELTA_UPDATE='0'
 
@@ -93,6 +96,8 @@ ADUC_PUBLIC_KEY=''
 ADU_EMBED_TEST_ROOT_KEYS=0
 CLEAN_SSTATE_RECIPE_NAME=''
 SHOW_RECIPES=0
+BB_NUMBER_THREADS=''
+PARALLEL_MAKE=''
 
 while [[ $1 != "" ]]; do
     case $1 in
@@ -200,6 +205,14 @@ while [[ $1 != "" ]]; do
     --verbose)
         VERBOSE='-v'
         ;;
+    -j | --jobs)
+        shift
+        BB_NUMBER_THREADS="$1"
+        ;;
+    --parallel-make)
+        shift
+        PARALLEL_MAKE="$1"
+        ;;
     *)
         echo "Unknown option: $1" >&2
         print_help
@@ -224,15 +237,56 @@ if [ -n "${ADU_GIT_BRANCH}" ]; then
     export ADU_GIT_BRANCH
 fi
 
-# if ADU_GIT_COMMIT is not set and not equal "AUTOREV", then use the latest commit
+# if ADU_GIT_COMMIT is not set and not equal "AUTOREV", then fetch the HEAD commit of the branch
 if [ "${ADU_GIT_COMMIT}" = "AUTOREV" ]; then
     echo "ADU_GIT_COMMIT is set to AUTOREV, using latest commit."
     export ADU_GIT_COMMIT=""
 elif [ -z "${ADU_GIT_COMMIT}" ]; then
+    echo "ADU_GIT_COMMIT not set, fetching HEAD commit hash for branch '${ADU_GIT_BRANCH}'..."
+    
+    # Validate ADU_SRC_URI is set
+    if [ -z "${ADU_SRC_URI}" ]; then
+        echo "ERROR: ADU_SRC_URI is not set. Cannot fetch commit hash."
+        exit 1
+    fi
+    
+    # Extract repo URL and convert to HTTPS format for git ls-remote
+    # Handle git://, https://, and http:// protocols
+    REPO_URL="${ADU_SRC_URI}"
+    if [[ "${REPO_URL}" == git://* ]]; then
+        REPO_URL="https://${REPO_URL#git://}"
+    elif [[ "${REPO_URL}" == http://* ]]; then
+        REPO_URL="https://${REPO_URL#http://}"
+    fi
+    
+    # Validate the URL format
+    if [[ ! "${REPO_URL}" =~ ^https://[a-zA-Z0-9.-]+/[a-zA-Z0-9._/-]+$ ]]; then
+        echo "ERROR: Invalid repository URL format: ${ADU_SRC_URI}"
+        echo "Expected format: git://github.com/owner/repo or https://github.com/owner/repo"
+        exit 1
+    fi
+    
+    echo "Fetching from: ${REPO_URL}"
+    
+    # Fetch the commit hash for the specified branch
+    ADU_GIT_COMMIT=$(git ls-remote "${REPO_URL}" "refs/heads/${ADU_GIT_BRANCH}" 2>&1 | grep -v "^fatal:" | cut -f1)
+    
+    if [ -z "${ADU_GIT_COMMIT}" ]; then
+        echo "ERROR: Failed to fetch commit hash for branch '${ADU_GIT_BRANCH}' from ${REPO_URL}"
+        echo "Please check that:"
+        echo "  1. The repository URL is correct and accessible"
+        echo "  2. The branch '${ADU_GIT_BRANCH}' exists"
+        echo "  3. You have network connectivity"
+        echo "Alternatively, specify --adu-git-commit manually."
+        exit 1
+    fi
+    
+    echo "✓ Using ADU_GIT_COMMIT: ${ADU_GIT_COMMIT} (HEAD of branch '${ADU_GIT_BRANCH}')"
     export ADU_GIT_COMMIT
 fi
 
 if [ -n "${ADU_GIT_COMMIT}" ]; then
+    echo "ADU_GIT_COMMIT is set to: ${ADU_GIT_COMMIT}"
     export ADU_GIT_COMMIT
 fi
 
@@ -303,15 +357,42 @@ if (( [ -z "$ADUC_PRIVATE_KEY" ] || [ ! -f "$ADUC_PRIVATE_KEY" ] ) || \
 fi
 
 # Remove all build output files for a full rebuild.
+# Note: We preserve the sstate-cache in a separate location to speed up rebuilds
 if [[ $REBUILD == 'true' ]]; then
-    rm -rf $BUILD_DIR/*
+    echo "Performing full rebuild - removing build directory contents (preserving sstate cache)..."
+    # Remove everything except sstate-cache if it exists
+    find $BUILD_DIR -mindepth 1 -maxdepth 1 ! -name 'sstate-cache' -exec rm -rf {} + 2>/dev/null || true
 fi
 
+# Use persistent sstate cache location outside the tmp build directory
+# This allows the cache to survive full rebuilds
 export SSTATE_DIR=$BUILD_DIR/sstate-cache
+mkdir -p $SSTATE_DIR
+echo "Using SSTATE_DIR: $SSTATE_DIR"
+
+# Set parallel build options for faster builds
+# BB_NUMBER_THREADS: Number of parallel BitBake tasks
+# PARALLEL_MAKE: Number of processes make should run in parallel (e.g., -j 8)
+NPROC=$(nproc 2>/dev/null || echo "4")
+
+if [ -z "${BB_NUMBER_THREADS}" ]; then
+    BB_NUMBER_THREADS="${NPROC}"
+fi
+
+if [ -z "${PARALLEL_MAKE}" ]; then
+    PARALLEL_MAKE="${NPROC}"
+fi
+
+export BB_NUMBER_THREADS
+export PARALLEL_MAKE="-j ${PARALLEL_MAKE}"
+
+echo "Parallel build settings:"
+echo "  BB_NUMBER_THREADS: ${BB_NUMBER_THREADS} (BitBake parallel tasks)"
+echo "  PARALLEL_MAKE: ${PARALLEL_MAKE} (make parallel processes)"
 
 # export TOP_DIR=$ROOT_DIR/yocto
 # We need to tell bitbake about any env vars it should read in.
-export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS ADUC_USE_TEST_ROOT_KEYS ADU_GENERATION ADU_GIT_BRANCH ADU_SRC_URI ADU_GIT_COMMIT DO_GIT_BRANCH DO_SRC_URI DO_GIT_COMMIT ADU_DELTA_GIT_BRANCH ADU_DELTA_SRC_URI ADU_DELTA_GIT_COMMIT BUILD_TYPE ADU_SOFTWARE_VERSION ADUC_PUBLIC_KEY ADUC_PRIVATE_KEY ADUC_PRIVATE_KEY_PASSWORD SSTATE_DIR"
+export BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_PASSTHROUGH_ADDITIONS ADUC_USE_TEST_ROOT_KEYS ADU_GENERATION ADU_GIT_BRANCH ADU_SRC_URI ADU_GIT_COMMIT DO_GIT_BRANCH DO_SRC_URI DO_GIT_COMMIT ADU_DELTA_GIT_BRANCH ADU_DELTA_SRC_URI ADU_DELTA_GIT_COMMIT BUILD_TYPE ADU_SOFTWARE_VERSION ADUC_PUBLIC_KEY ADUC_PRIVATE_KEY ADUC_PRIVATE_KEY_PASSWORD SSTATE_DIR BB_NUMBER_THREADS PARALLEL_MAKE"
 source $ROOT_DIR/poky/oe-init-build-env $BUILD_DIR
 
 if [[ $SHOW_RECIPES == 1 ]]; then


### PR DESCRIPTION
- Automatically fetch HEAD commit hash from ADU_GIT_BRANCH instead of using hardcoded value
- Add URL validation with git:// to https:// protocol conversion
- Add -j/--jobs and --parallel-make options for parallel builds with auto CPU detection
- Preserve sstate-cache during --rebuild for better performance
- Update README.md with new features