### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/test-delta-build.yml
+++ b/.github/workflows/test-delta-build.yml
@@ -29,7 +29,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: recursive
       
@@ -173,7 +173,7 @@ jobs:
       
       - name: Upload build logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: delta-build-logs
           path: |

--- a/.github/workflows/yocto-build-incremental.yml
+++ b/.github/workflows/yocto-build-incremental.yml
@@ -29,7 +29,7 @@ jobs:
           df -h
       
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0  # Full history for better change detection
       
@@ -49,7 +49,7 @@ jobs:
       
       # Aggressive caching strategy
       - name: Restore downloads cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         id: cache-downloads
         with:
           path: ${{ env.BUILD_DIR }}/build/downloads
@@ -58,7 +58,7 @@ jobs:
             yocto-dl-${{ env.YOCTO_RELEASE }}-
       
       - name: Restore sstate cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         id: cache-sstate
         with:
           path: ${{ env.BUILD_DIR }}/build/sstate-cache
@@ -94,21 +94,21 @@ jobs:
       
       - name: Save downloads cache
         if: steps.cache-downloads.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ env.BUILD_DIR }}/build/downloads
           key: ${{ steps.cache-downloads.outputs.cache-primary-key }}
       
       - name: Save sstate cache
         if: always()
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ env.BUILD_DIR }}/build/sstate-cache
           key: yocto-sstate-${{ env.YOCTO_RELEASE }}-${{ github.base_ref || github.ref_name }}-${{ github.sha }}
       
       - name: Upload artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr-build-${{ github.event.pull_request.number }}
           path: |

--- a/.github/workflows/yocto-build-self-hosted.yml
+++ b/.github/workflows/yocto-build-self-hosted.yml
@@ -56,7 +56,7 @@ jobs:
           git reset --hard
       
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: recursive
           lfs: true
@@ -170,7 +170,7 @@ jobs:
       
       - name: Upload to GitHub
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: yocto-build-${{ github.ref_name }}-${{ github.sha }}
           path: |

--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -42,7 +42,7 @@ jobs:
           remove-docker-images: 'true'
       
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: recursive
       
@@ -65,7 +65,7 @@ jobs:
           echo "⚠️  WARNING: These are TEST keys only. Do not use in production!"
       
       - name: Cache Yocto downloads
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ env.BUILD_DIR }}/build/downloads
           key: yocto-downloads-${{ env.YOCTO_RELEASE }}-${{ hashFiles('**/recipes-*/**/*.bb', '**/recipes-*/**/*.bbappend') }}
@@ -73,7 +73,7 @@ jobs:
             yocto-downloads-${{ env.YOCTO_RELEASE }}-
       
       - name: Cache sstate
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ env.BUILD_DIR }}/build/sstate-cache
           key: yocto-sstate-${{ env.YOCTO_RELEASE }}-${{ github.sha }}
@@ -106,7 +106,7 @@ jobs:
       
       - name: Upload build artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: yocto-images-${{ github.sha }}
           path: |
@@ -116,7 +116,7 @@ jobs:
       
       - name: Upload SBOM
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sbom-${{ github.sha }}
           path: |


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
